### PR TITLE
Fix missing import in ExportService

### DIFF
--- a/app/src/main/java/com/example/clearchoice/ExportService.kt
+++ b/app/src/main/java/com/example/clearchoice/ExportService.kt
@@ -6,6 +6,7 @@ import android.graphics.Paint
 import android.graphics.pdf.PdfDocument
 import android.net.Uri
 import android.util.Log
+import android.widget.Toast
 import androidx.core.content.FileProvider
 import org.json.JSONObject
 import java.io.File


### PR DESCRIPTION
## Summary
- add missing Toast import for ExportService

## Testing
- `gradle tasks` *(fails: plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840fba422988326b89deabc507bf6f7