### PR TITLE
Add ABI filter configuration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,6 +15,9 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        ndk {
+            abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64'
+        }
     }
 
     buildTypes {


### PR DESCRIPTION
## Summary
- specify ABI filters for arm and x86 in `defaultConfig`

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840febc30dc8326a386715711dcdb15