### PR TITLE
Guard against accidental main.cpp inclusion

### DIFF
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -27,6 +27,9 @@ add_library( # Sets the name of the library.
         diarization_module/speaker_clusterer.cpp
         )
 
+# Prevent accidental inclusion of standalone entry points.
+set_source_files_properties(main.cpp PROPERTIES HEADER_FILE_ONLY TRUE)
+
 # Include directories
 target_include_directories(native-lib PRIVATE
     ${CMAKE_SOURCE_DIR}/whisper_cpp


### PR DESCRIPTION
## Summary
- update `app/src/main/cpp/CMakeLists.txt` to mark `main.cpp` as header-only

## Testing
- `cmake ../app/src/main/cpp`
- `make -j$(nproc)` *(fails: jni.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840feb8ec748326886940ffd543ab41