### PR TITLE
Fix missing repos and header forward declarations

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,12 @@ plugins {
     id 'org.jetbrains.kotlin.android'
 }
 
+// Define repositories here as well so building the module directly still works
+repositories {
+    google()
+    mavenCentral()
+}
+
 android {
     namespace 'com.example.clearchoice'
     compileSdk 34

--- a/app/src/main/cpp/whisper_cpp/ggml.h
+++ b/app/src/main/cpp/whisper_cpp/ggml.h
@@ -6,6 +6,12 @@
 #include <stddef.h>
 #include <stdbool.h>
 
+/* Forward declarations used by function prototypes below.  Declaring them
+ * early avoids potential visibility warnings with some compilers when the
+ * full definitions appear later in the file. */
+struct ggml_context;
+struct ggml_init_params;
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
## Summary
- add repository definitions so module builds standalone
- avoid visibility warnings by forward declaring ggml structs

## Testing
- `gradle -q :app:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841017aa30c8326829aacc582b5c477